### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-GhostLab42Reboot	    KEYWORD1
-begin	                KEYWORD2
-write	                KEYWORD2
-resetDisplay	        KEYWORD2
+GhostLab42Reboot	KEYWORD1
+begin	KEYWORD2
+write	KEYWORD2
+resetDisplay	KEYWORD2
 setDisplayBrightness	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords